### PR TITLE
Remove extra import (Fix 1 warning: redundant Control.Monad.IO.Class)

### DIFF
--- a/Web/Authenticate/LDAP.hs
+++ b/Web/Authenticate/LDAP.hs
@@ -14,7 +14,6 @@ module Web.Authenticate.LDAP
 import Data.Text (Text,unpack)
 import LDAP
 import Control.Exception
-import Control.Monad.IO.Class
   
 data LDAPAuthResult = Ok LDAPEntry
                     | NoSuchUser


### PR DESCRIPTION
Minor change. It compiles without warning.